### PR TITLE
Better paths handling for JS load-in.

### DIFF
--- a/Extension.php
+++ b/Extension.php
@@ -61,7 +61,7 @@ class Extension extends \Bolt\BaseExtension
         // Insert out JS late so that we are more likely to work with a late
         // jQuery insertion
         $html .= '
-            <script defer src="/' . $this->config['path'] . '/js/bolt.socialite.min.js"></script>
+            <script defer src="' . $this->app['paths']['root'] . $this->config['path'] . '/js/bolt.socialite.min.js"></script>
             ';
 
         $this->addSnippet(SnippetLocation::END_OF_HTML, $html);


### PR DESCRIPTION
Allow Socialite JS to load on Bolt sites installed @ subdirectories. $this->app['paths']['root'] === "/" when Bolt installed @ domain root, else is "/mySitesDirectory/" or something. Is an issue which on my local server where I have Bolt site at http://myHomeServerDomain.me/MyTestingSite/ and JS doesn't load which this edit fixes.