### PR TITLE
Fixes, extensions path problem and problem with array of social buttons

### DIFF
--- a/Extension.php
+++ b/Extension.php
@@ -54,14 +54,14 @@ class Extension extends \Bolt\BaseExtension
 
         // If we're set to actviate by scroll, add a class to <body> that gets
         // caught in socialite.load.js
-        if (empty($this->config['activation']) || $this->config['activation'] = 'scroll') {
+        if (empty($this->config['activation']) || $this->config['activation'] == 'scroll') {
             $html = '<script>document.body.className += "socialite-scroll";</script>';
         }
 
         // Insert out JS late so that we are more likely to work with a late
         // jQuery insertion
         $html .= '
-            <script defer src="' . $this->app['resources']->getUrl('root') . $this->config['path'] . '/js/bolt.socialite.min.js"></script>
+            <script defer src="' . str_replace("//","/",$this->app['resources']->getUrl('root') . $this->config['path']) . '/js/bolt.socialite.min.js"></script>
             ';
 
         $this->addSnippet(SnippetLocation::END_OF_HTML, $html);

--- a/src/Widget.php
+++ b/src/Widget.php
@@ -26,16 +26,20 @@ class Widget
             $buttons = array($buttons => $buttons);
         }
 
+$html="";
+
         // Insert a <div><a> for each module called this time
         foreach ($buttons as $key => $value) {
-            if (is_numeric($key) && method_exists($this, $value)) {
-                $html = call_user_func(array($this, $value), false);
-                return new \Twig_Markup($html, 'UTF-8');
+
+                if (is_numeric($key) && method_exists($this, $value)) {
+                $html.= call_user_func(array($this, $value), false);
+
             } elseif (method_exists($this, $key)) {
-                $html = call_user_func(array($this, $key), $value);
-                return new \Twig_Markup($html, 'UTF-8');
+                $html.= call_user_func(array($this, $key), $value);
+
             }
         }
+        return new \Twig_Markup($html, 'UTF-8');
     }
 
     private function getRecord()
@@ -289,7 +293,7 @@ class Widget
 
     private function PinterestPinit()
     {
-        if (empty($this->config['pinterest_pinit_size']) || $this->config['pinterest_pinit_size'] = 'small') {
+        if (empty($this->config['pinterest_pinit_size']) || $this->config['pinterest_pinit_size'] == 'small') {
             $this->config['pinterest_pinit_size'] = "20";
         } elseif ($this->config['pinterest_pinit_size'] == 'large') {
             $this->config['pinterest_pinit_size'] = "28";


### PR DESCRIPTION
I have found the following problems with your extension, I hope this is useful for you:

1.-First change is that there is an equal instead of two equals, I suppose this is a bug, because I haven't used it.

2.-I have added a replace function in the event where the result of:
$this->app['resources']->getUrl('root') . $this->config['path']
Is "whatever/" + "/", creating the path: "//" which gives me an error to retrieve the js as it looks for: 

http://extensions/vendor/bolt/.....

I found the same problem with the plugin editable, and Rix beck accepted the change:

https://github.com/rixbeck/bolt-extension-editable/issues/11

3.-When you want to pass more than one network in the function socialite, I write this:
{{ socialite(['TwitterShare', .... ,....]) }}

In the code, the loop only takes the first one, because once you use the "return", the second is forgotten.
This is why in the code, instead of returning, I do a concat.

Hope this helps. Bolt rocks!
